### PR TITLE
Change menu font styles to fit sidebar

### DIFF
--- a/themes/falconf/src/styles/sidebar.scss
+++ b/themes/falconf/src/styles/sidebar.scss
@@ -11,19 +11,6 @@
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
   @include transition(width 0.5s ease);
 
-  &::-webkit-scrollbar {
-    background: transparent;
-    width: 4px;
-  }
-
-  &::-webkit-scrollbar-button {
-    display: none;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    border-radius: 1px;
-  }
-
   .df-sidebar-nav {
     position: absolute;
     margin: 0;
@@ -33,18 +20,19 @@
     display: none;
 
     a {
-      padding: 1em 0;
       font-family: 'Roboto Mono', monospace;
-      font-weight: 500;
-      font-size: 1.2rem;
-      text-decoration: underline;
+      padding: 0.5em 0;
+      font-weight: 300;
+      font-size: 1rem;
       text-transform: uppercase;
       color: inherit;
       display: block;
+      line-height: 1.4;
+      letter-spacing: 0.05em;
 
       &:hover,
       &.active {
-        text-decoration: none;
+        text-decoration: underline;
       }
     }
   }


### PR DESCRIPTION
We have more and more items in the sidebar, so I think we should make menu items smaller to fit in one "screen" without necessity to scroll.